### PR TITLE
Fixed `HumidAir.Mixing` method

### DIFF
--- a/src/SharpProp/HumidAir/HumidAirProcesses.cs
+++ b/src/SharpProp/HumidAir/HumidAirProcesses.cs
@@ -101,10 +101,22 @@ public partial class HumidAir
                     ) / (firstSpecificMassFlow + secondSpecificMassFlow).DecimalFractions
                 ),
                 InputHumidAir.Humidity(
-                    (
-                        firstSpecificMassFlow.DecimalFractions * first.Humidity
-                        + secondSpecificMassFlow.DecimalFractions * second.Humidity
-                    ) / (firstSpecificMassFlow + secondSpecificMassFlow).DecimalFractions
+                    Ratio.FromDecimalFractions(
+                        (
+                            firstSpecificMassFlow.DecimalFractions
+                                * first.Humidity.DecimalFractions
+                                * (1 + second.Humidity.DecimalFractions)
+                            + secondSpecificMassFlow.DecimalFractions
+                                * second.Humidity.DecimalFractions
+                                * (1 + first.Humidity.DecimalFractions)
+                        )
+                            / (
+                                firstSpecificMassFlow.DecimalFractions
+                                    * (1 + second.Humidity.DecimalFractions)
+                                + secondSpecificMassFlow.DecimalFractions
+                                    * (1 + first.Humidity.DecimalFractions)
+                            )
+                    )
                 )
             )
             : throw new ArgumentException(

--- a/tests/SharpProp.Tests/HumidAir/HumidAirProcessesTests.cs
+++ b/tests/SharpProp.Tests/HumidAir/HumidAirProcessesTests.cs
@@ -426,7 +426,22 @@ public class TestHumidAirProcesses
                 _humidAir.WithState(
                     InputHumidAir.Pressure(_humidAir.Pressure),
                     InputHumidAir.Enthalpy((1 * first.Enthalpy + 2 * second.Enthalpy) / 3.0),
-                    InputHumidAir.Humidity((1 * first.Humidity + 2 * second.Humidity) / 3.0)
+                    InputHumidAir.Humidity(
+                        Ratio.FromDecimalFractions(
+                            (
+                                1
+                                    * first.Humidity.DecimalFractions
+                                    * (1 + second.Humidity.DecimalFractions)
+                                + 2
+                                    * second.Humidity.DecimalFractions
+                                    * (1 + first.Humidity.DecimalFractions)
+                            )
+                                / (
+                                    1 * (1 + second.Humidity.DecimalFractions)
+                                    + 2 * (1 + first.Humidity.DecimalFractions)
+                                )
+                        )
+                    )
                 )
             );
     }


### PR DESCRIPTION
Fixed `HumidAir.Mixing` method according to https://github.com/portyanikhin/PyFluids/pull/57
