### PR TITLE
Add native CoolProp SetMoleFractions support for mixture composition

### DIFF
--- a/src/SharpProp/CoolProp/AbstractState.cs
+++ b/src/SharpProp/CoolProp/AbstractState.cs
@@ -58,6 +58,12 @@ public class AbstractState : IDisposable
         SwigExceptions.ThrowPendingException();
     }
 
+    public void SetMoleFractions(DoubleVector moleFractions)
+    {
+        AbstractStatePInvoke.SetMoleFractions(_handle, moleFractions.Handle);
+        SwigExceptions.ThrowPendingException();
+    }
+
     public void SetVolumeFractions(DoubleVector volumeFractions)
     {
         AbstractStatePInvoke.SetVolumeFractions(_handle, volumeFractions.Handle);

--- a/src/SharpProp/CoolProp/AbstractStatePInvoke.cs
+++ b/src/SharpProp/CoolProp/AbstractStatePInvoke.cs
@@ -13,6 +13,9 @@ internal static class AbstractStatePInvoke
     [DllImport(Library.Name, EntryPoint = "CSharp_AbstractState_set_mass_fractions")]
     public static extern void SetMassFractions(HandleRef abstractState, HandleRef massFractions);
 
+    [DllImport(Library.Name, EntryPoint = "CSharp_AbstractState_set_mole_fractions")]
+    public static extern void SetMoleFractions(HandleRef abstractState, HandleRef moleFractions);
+
     [DllImport(Library.Name, EntryPoint = "CSharp_AbstractState_set_volu_fractions")]
     public static extern void SetVolumeFractions(
         HandleRef abstractState,


### PR DESCRIPTION
**Problem**

The current SharpProp wrapper is missing the SetMoleFractions method that exists in the underlying CoolProp library. This creates an inconsistency where users can set mass fractions (SetMassFractions) and volume fractions (SetVolumeFractions) but cannot set mole fractions directly through the native CoolProp interface.

**Solution**

This PR adds complete native CoolProp integration for mole fractions:

Low-level CoolProp Integration:
  - Added SetMoleFractions P/Invoke method to AbstractStatePInvoke.cs
  - Added SetMoleFractions wrapper method to AbstractState.cs with proper exception handling
  - Follows the same pattern as existing SetMassFractions and SetVolumeFractions methods

**Benefits**

  - API Completeness: Provides full parity with CoolProp's fraction setting capabilities
  - Foundation for Future Development: Enables future high-level mole fraction APIs
  - Real-World Applications: Enables accurate thermodynamic calculations for multi-component gas mixtures where mole fractions are the preferred input format
  - Backward Compatibility: No breaking changes to existing APIs