### PR TITLE
feat: add new fluids and mixtures from `CoolProp` v8

### DIFF
--- a/src/SharpProp/Enums/FluidsList.cs
+++ b/src/SharpProp/Enums/FluidsList.cs
@@ -723,13 +723,13 @@ public enum FluidsList
     [FluidInfo("MAM", "INCOMP", false, Mix.Mass, 0, 0.3)]
     MAM,
 
-    [FluidInfo("MAM2", "INCOMP", false, Mix.Mass, 0.078, 0.236)]
+    [FluidInfo("MAM2", "INCOMP", false, Mix.Mass, 0.08, 0.24)]
     MAM2,
 
     [FluidInfo("MCA", "INCOMP", false, Mix.Mass, 0, 0.3)]
     MCA,
 
-    [FluidInfo("MCA2", "INCOMP", false, Mix.Mass, 0.09, 0.294)]
+    [FluidInfo("MCA2", "INCOMP", false, Mix.Mass, 0.09, 0.29)]
     MCA2,
 
     [FluidInfo("MEA", "INCOMP", false, Mix.Mass, 0, 0.6)]
@@ -747,7 +747,7 @@ public enum FluidsList
     [FluidInfo("MGL", "INCOMP", false, Mix.Mass, 0, 0.6)]
     MGL,
 
-    [FluidInfo("MGL2", "INCOMP", false, Mix.Mass, 0.195, 0.63)]
+    [FluidInfo("MGL2", "INCOMP", false, Mix.Mass, 0.2, 0.63)]
     MGL2,
 
     [FluidInfo("MITSW", "INCOMP", false, Mix.Mass, 0, 0.12)]
@@ -774,13 +774,13 @@ public enum FluidsList
     [FluidInfo("MMA", "INCOMP", false, Mix.Mass, 0, 0.6)]
     MMA,
 
-    [FluidInfo("MMA2", "INCOMP", false, Mix.Mass, 0.078, 0.474)]
+    [FluidInfo("MMA2", "INCOMP", false, Mix.Mass, 0.08, 0.47)]
     MMA2,
 
     [FluidInfo("MMG", "INCOMP", false, Mix.Mass, 0, 0.3)]
     MMG,
 
-    [FluidInfo("MMG2", "INCOMP", false, Mix.Mass, 0, 0.205)]
+    [FluidInfo("MMG2", "INCOMP", false, Mix.Mass, 0, 0.21)]
     MMG2,
 
     [FluidInfo("MNA", "INCOMP", false, Mix.Mass, 0, 0.23)]
@@ -795,26 +795,26 @@ public enum FluidsList
     [FluidInfo("MPG2", "INCOMP", false, Mix.Mass, 0.15, 0.57)]
     MPG2,
 
-    [FluidInfo("VCA", "INCOMP", false, Mix.Mass, 0.147, 0.299)]
+    [FluidInfo("VCA", "INCOMP", false, Mix.Mass, 0.15, 0.3)]
     VCA,
 
-    [FluidInfo("VKC", "INCOMP", false, Mix.Mass, 0.128, 0.389)]
+    [FluidInfo("VKC", "INCOMP", false, Mix.Mass, 0.13, 0.39)]
     VKC,
 
     [FluidInfo("VMA", "INCOMP", false, Mix.Mass, 0.1, 0.9)]
     VMA,
 
-    [FluidInfo("VMG", "INCOMP", false, Mix.Mass, 0.072, 0.206)]
+    [FluidInfo("VMG", "INCOMP", false, Mix.Mass, 0.07, 0.21)]
     VMG,
 
-    [FluidInfo("VNA", "INCOMP", false, Mix.Mass, 0.07, 0.231)]
+    [FluidInfo("VNA", "INCOMP", false, Mix.Mass, 0.07, 0.23)]
     VNA,
 
     // Incompressible volume-based binary mixtures
     [FluidInfo("AEG", "INCOMP", false, Mix.Volume, 0.1, 0.6)]
     AEG,
 
-    [FluidInfo("AKF", "INCOMP", false, Mix.Volume, 0.4)]
+    [FluidInfo("AKF", "INCOMP", false, Mix.Volume, 0.4, 1.00)]
     AKF,
 
     [FluidInfo("AL", "INCOMP", false, Mix.Volume, 0.1, 0.6)]
@@ -829,7 +829,7 @@ public enum FluidsList
     [FluidInfo("GKN", "INCOMP", false, Mix.Volume, 0.1, 0.6)]
     GKN,
 
-    [FluidInfo("PK2", "INCOMP", false, Mix.Volume, 0.3)]
+    [FluidInfo("PK2", "INCOMP", false, Mix.Volume, 0.3, 1.00)]
     PK2,
 
     [FluidInfo("PKL", "INCOMP", false, Mix.Volume, 0.1, 0.6)]
@@ -844,7 +844,7 @@ public enum FluidsList
     [FluidInfo("ZLC", "INCOMP", false, Mix.Volume, 0.3, 0.7)]
     ZLC,
 
-    [FluidInfo("ZM", "INCOMP", false, Mix.Volume)]
+    [FluidInfo("ZM", "INCOMP", false, Mix.Volume, 0, 1.00)]
     ZM,
 
     [FluidInfo("ZMC", "INCOMP", false, Mix.Volume, 0.3, 0.7)]

--- a/src/SharpProp/Enums/FluidsList.cs
+++ b/src/SharpProp/Enums/FluidsList.cs
@@ -52,6 +52,9 @@ public enum FluidsList
     [FluidInfo("CarbonylSulfide")]
     CarbonylSulfide,
 
+    [FluidInfo("Chlorine")]
+    Chlorine,
+
     [FluidInfo("cis-2-Butene")]
     cis2Butene,
 
@@ -253,6 +256,15 @@ public enum FluidsList
     [FluidInfo("n-Pentane")]
     R601,
 
+    [FluidInfo("n-Perfluorobutane")]
+    nPerfluorobutane,
+
+    [FluidInfo("n-Perfluorohexane")]
+    nPerfluorohexane,
+
+    [FluidInfo("n-Perfluoropentane")]
+    nPerfluoropentane,
+
     [FluidInfo("n-Propane")]
     nPropane,
 
@@ -286,6 +298,9 @@ public enum FluidsList
     [FluidInfo("Propylene")]
     Propylene,
 
+    [FluidInfo("PropyleneGlycol")]
+    PropyleneGlycol,
+
     [FluidInfo("Propylene")]
     R1270,
 
@@ -298,8 +313,17 @@ public enum FluidsList
     [FluidInfo("R11")]
     R11,
 
+    [FluidInfo("R1123")]
+    R1123,
+
     [FluidInfo("R113")]
     R113,
+
+    [FluidInfo("R1130(E)")]
+    R1130E,
+
+    [FluidInfo("R1132(E)")]
+    R1132E,
 
     [FluidInfo("R114")]
     R114,
@@ -312,6 +336,9 @@ public enum FluidsList
 
     [FluidInfo("R12")]
     R12,
+
+    [FluidInfo("R1224YDZ")]
+    R1224ydZ,
 
     [FluidInfo("R123")]
     R123,
@@ -342,6 +369,9 @@ public enum FluidsList
 
     [FluidInfo("R1336mzz(E)")]
     R1336mzzE,
+
+    [FluidInfo("R1336mzz(Z)")]
+    R1336mzzZ,
 
     [FluidInfo("R134a")]
     R134a,
@@ -436,8 +466,14 @@ public enum FluidsList
     [FluidInfo("SulfurHexafluoride")]
     R846,
 
+    [FluidInfo("Tetrahydrofuran")]
+    Tetrahydrofuran,
+
     [FluidInfo("Toluene")]
     Toluene,
+
+    [FluidInfo("VinylChloride")]
+    VinylChloride,
 
     [FluidInfo("trans-2-Butene")]
     trans2Butene,
@@ -464,6 +500,12 @@ public enum FluidsList
     [FluidInfo("AS40", "INCOMP")]
     AS40,
 
+    [FluidInfo("Acetone", "INCOMP")]
+    AcetoneIncomp,
+
+    [FluidInfo("Air", "INCOMP")]
+    AirIncomp,
+
     [FluidInfo("AS55", "INCOMP")]
     AS55,
 
@@ -484,6 +526,30 @@ public enum FluidsList
 
     [FluidInfo("DSF", "INCOMP")]
     DSF,
+
+    [FluidInfo("Ethanol", "INCOMP")]
+    EthanolIncomp,
+
+    [FluidInfo("FoodAsh", "INCOMP")]
+    FoodAsh,
+
+    [FluidInfo("FoodCarbohydrate", "INCOMP")]
+    FoodCarbohydrate,
+
+    [FluidInfo("FoodFat", "INCOMP")]
+    FoodFat,
+
+    [FluidInfo("FoodFiber", "INCOMP")]
+    FoodFiber,
+
+    [FluidInfo("FoodIce", "INCOMP")]
+    FoodIce,
+
+    [FluidInfo("FoodProtein", "INCOMP")]
+    FoodProtein,
+
+    [FluidInfo("FoodWater", "INCOMP")]
+    FoodWater,
 
     [FluidInfo("HC10", "INCOMP")]
     HC10,
@@ -526,6 +592,12 @@ public enum FluidsList
 
     [FluidInfo("HY50", "INCOMP")]
     HY50,
+
+    [FluidInfo("Hexane", "INCOMP")]
+    HexaneIncomp,
+
+    [FluidInfo("LiqNa", "INCOMP")]
+    LiqNa,
 
     [FluidInfo("NaK", "INCOMP")]
     NaK,
@@ -851,6 +923,15 @@ public enum FluidsList
     [FluidInfo("R407F.mix")]
     R407F,
 
+    [FluidInfo("R407G.mix")]
+    R407G,
+
+    [FluidInfo("R407H.mix")]
+    R407H,
+
+    [FluidInfo("R407I.mix")]
+    R407I,
+
     [FluidInfo("R408A.mix")]
     R408A,
 
@@ -950,6 +1031,9 @@ public enum FluidsList
     [FluidInfo("R427A.mix")]
     R427A,
 
+    [FluidInfo("R427C.mix")]
+    R427C,
+
     [FluidInfo("R428A.mix")]
     R428A,
 
@@ -985,6 +1069,9 @@ public enum FluidsList
 
     [FluidInfo("R436B.mix")]
     R436B,
+
+    [FluidInfo("R436C.mix")]
+    R436C,
 
     [FluidInfo("R437A.mix")]
     R437A,
@@ -1022,14 +1109,23 @@ public enum FluidsList
     [FluidInfo("R447A.mix")]
     R447A,
 
+    [FluidInfo("R447B.mix")]
+    R447B,
+
     [FluidInfo("R448A.mix")]
     R448A,
+
+    [FluidInfo("R448B.mix")]
+    R448B,
 
     [FluidInfo("R449A.mix")]
     R449A,
 
     [FluidInfo("R449B.mix")]
     R449B,
+
+    [FluidInfo("R449C.mix")]
+    R449C,
 
     [FluidInfo("R450A.mix")]
     R450A,
@@ -1043,6 +1139,12 @@ public enum FluidsList
     [FluidInfo("R452A.mix")]
     R452A,
 
+    [FluidInfo("R452B.mix")]
+    R452B,
+
+    [FluidInfo("R452C.mix")]
+    R452C,
+
     [FluidInfo("R453A.mix")]
     R453A,
 
@@ -1051,6 +1153,102 @@ public enum FluidsList
 
     [FluidInfo("R454B.mix")]
     R454B,
+
+    [FluidInfo("R454C.mix")]
+    R454C,
+
+    [FluidInfo("R455A.mix")]
+    R455A,
+
+    [FluidInfo("R456A.mix")]
+    R456A,
+
+    [FluidInfo("R457A.mix")]
+    R457A,
+
+    [FluidInfo("R457B.mix")]
+    R457B,
+
+    [FluidInfo("R457C.mix")]
+    R457C,
+
+    [FluidInfo("R458A.mix")]
+    R458A,
+
+    [FluidInfo("R459A.mix")]
+    R459A,
+
+    [FluidInfo("R459B.mix")]
+    R459B,
+
+    [FluidInfo("R460A.mix")]
+    R460A,
+
+    [FluidInfo("R460B.mix")]
+    R460B,
+
+    [FluidInfo("R460C.mix")]
+    R460C,
+
+    [FluidInfo("R461A.mix")]
+    R461A,
+
+    [FluidInfo("R462A.mix")]
+    R462A,
+
+    [FluidInfo("R463A.mix")]
+    R463A,
+
+    [FluidInfo("R464A.mix")]
+    R464A,
+
+    [FluidInfo("R465A.mix")]
+    R465A,
+
+    [FluidInfo("R466A.mix")]
+    R466A,
+
+    [FluidInfo("R467A.mix")]
+    R467A,
+
+    [FluidInfo("R468A.mix")]
+    R468A,
+
+    [FluidInfo("R468B.mix")]
+    R468B,
+
+    [FluidInfo("R468C.mix")]
+    R468C,
+
+    [FluidInfo("R469A.mix")]
+    R469A,
+
+    [FluidInfo("R470A.mix")]
+    R470A,
+
+    [FluidInfo("R470B.mix")]
+    R470B,
+
+    [FluidInfo("R471A.mix")]
+    R471A,
+
+    [FluidInfo("R472A.mix")]
+    R472A,
+
+    [FluidInfo("R472B.mix")]
+    R472B,
+
+    [FluidInfo("R473A.mix")]
+    R473A,
+
+    [FluidInfo("R474A.mix")]
+    R474A,
+
+    [FluidInfo("R475A.mix")]
+    R475A,
+
+    [FluidInfo("R476A.mix")]
+    R476A,
 
     [FluidInfo("R500.mix")]
     R500,

--- a/tests/SharpProp.Tests/Enums/FluidsListTests.cs
+++ b/tests/SharpProp.Tests/Enums/FluidsListTests.cs
@@ -22,6 +22,9 @@ public static class FluidsListTests
             case FluidsList.RE143a:
                 name.CoolPropName().Should().Be("HFE143m");
                 break;
+            case FluidsList.R1224ydZ:
+                name.CoolPropName().Should().Be("R1224YDZ");
+                break;
             case FluidsList.R152a:
                 name.CoolPropName().Should().Be("R152A");
                 break;
@@ -87,6 +90,18 @@ public static class FluidsListTests
                 break;
             case FluidsList.Butene:
                 name.CoolPropName().Should().Be("1-Butene");
+                break;
+            case FluidsList.AcetoneIncomp:
+                name.CoolPropName().Should().Be("Acetone");
+                break;
+            case FluidsList.AirIncomp:
+                name.CoolPropName().Should().Be("Air");
+                break;
+            case FluidsList.EthanolIncomp:
+                name.CoolPropName().Should().Be("Ethanol");
+                break;
+            case FluidsList.HexaneIncomp:
+                name.CoolPropName().Should().Be("Hexane");
                 break;
             case FluidsList.WaterIncomp:
                 name.CoolPropName().Should().Be("Water");

--- a/tests/SharpProp.Tests/Fluids/FluidTests.cs
+++ b/tests/SharpProp.Tests/Fluids/FluidTests.cs
@@ -7,6 +7,34 @@ public class FluidTests : IDisposable
     private const double Tolerance = 1e-9;
     private IFluid _fluid = new Fluid(FluidsList.Water);
 
+    private static readonly string[] Props =
+    [
+        "Z",
+        "L",
+        "p_critical",
+        "T_critical",
+        "D",
+        "V",
+        "H",
+        "S",
+        "T_freeze",
+        "U",
+        "P_max",
+        "T_max",
+        "P_min",
+        "T_min",
+        "M",
+        "Prandtl",
+        "P",
+        "Q",
+        "A",
+        "C",
+        "I",
+        "T",
+        "p_triple",
+        "T_triple",
+    ];
+
     public void Dispose()
     {
         _fluid.Dispose();
@@ -104,35 +132,7 @@ public class FluidTests : IDisposable
             fluid.TriplePressure?.Pascals,
             fluid.TripleTemperature?.Kelvins,
         };
-        var expected = new[]
-        {
-            "Z",
-            "L",
-            "p_critical",
-            "T_critical",
-            "D",
-            "V",
-            "H",
-            "S",
-            "T_freeze",
-            "U",
-            "P_max",
-            "T_max",
-            "P_min",
-            "T_min",
-            "M",
-            "Prandtl",
-            "P",
-            "Q",
-            "A",
-            "C",
-            "I",
-            "T",
-            "p_triple",
-            "T_triple",
-        }
-            .Select(CoolPropInterface)
-            .ToList();
+        var expected = Props.Select(CoolPropInterface).ToList();
         for (var i = 0; i < actual.Length; i++)
         {
             actual[i].Should().BeApproximately(expected[i], Tolerance);
@@ -373,7 +373,9 @@ public class FluidTests : IDisposable
             : Math.Round(0.5 * (name.FractionMin() + name.FractionMax()).Percent).Percent();
         _fluid = new Fluid(name, fraction);
         _fluid.Update(
-            Input.Pressure(_fluid.MaxPressure ?? 10.Megapascals()),
+            Input.Pressure(
+                name != FluidsList.LiqNa ? _fluid.MaxPressure ?? 10.Megapascals() : 1.Gigapascals()
+            ),
             Input.Temperature(_fluid.MaxTemperature)
         );
     }


### PR DESCRIPTION
Adds the following to the `FluidsList`:

- `Chlorine`
- `nPerfluorobutane`
- `nPerfluorohexane`
- `nPerfluoropentane`
- `PropyleneGlycol`
- `R1123`
- `R1130E`
- `R1132E`
- `R1224ydZ`
- `R1336mzzZ`
- `Tetrahydrofuran`
- `VinylChloride`
- `AcetoneIncomp`
- `AirIncomp`
- `EthanolIncomp`
- `FoodAsh`
- `FoodCarbohydrate`
- `FoodFat`
- `FoodFiber`
- `FoodIce`
- `FoodProtein`
- `FoodWater`
- `HexaneIncomp`
- `LiqNa`
- `R407G`
- `R407H`
- `R407I`
- `R427C`
- `R436C`
- `R447B`
- `R448B`
- `R449C`
- `R452B`
- `R452C`
- `R454C`
- `R455A`
- `R456A`
- `R457A`
- `R457B`
- `R457C`
- `R458A`
- `R459A`
- `R459B`
- `R460A`
- `R460B`
- `R460C`
- `R461A`
- `R462A`
- `R463A`
- `R464A`
- `R465A`
- `R466A`
- `R467A`
- `R468A`
- `R468B`
- `R468C`
- `R469A`
- `R470A`
- `R470B`
- `R471A`
- `R472A`
- `R472B`
- `R473A`
- `R474A`
- `R475A`
- `R476A`